### PR TITLE
Added Spaceduck to Terminator

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,5 +277,32 @@ BackgroundColour=15,17,27       # #0F111B
 CursorColour=236,240,193        # #ECF0C1
 ```
 
-# vivid
-copy `spaceduck-vivid.yml` to your `.config` then add `export LS_COLORS="$(vivid generate ~/.config/spaceduck-vivid.yml)"` to the end of your `.bashrc`
+## vivid
+Copy `spaceduck-vivid.yml` to your `.config`, then add `export LS_COLORS="$(vivid generate ~/.config/spaceduck-vivid.yml)"` to the end of your `.bashrc` file.
+
+## Terminator
+The recommended way to use spaceduck in your Terminator is to create a new profile. If you wish to do so,
+you can copy the contents of the `spaceduck.terminator` file and append them to your Terminator config 
+file (`~/.config/terminator/config`) as follows:
+
+```config
+# ...
+[profiles]
+  [[default]]
+    # WHATEVER YOUR 'default' PROFILE HAS
+    # ...
+  [[Spaceduck]]
+    background_color = "#0F111B"
+    cursor_color = "#ECF0C1"
+    cursor_color_fg = False
+    foreground_color = "#ECF0C1"
+    palette = "#000000:#e33400:#5ccc96:#b3a1e6:#00a3cc:#f2ce00:#7a5ccc:#686f9a:#686f9a:#e33400:#5ccc96:#b3a1e6:#00a3cc:#f2ce00:#7a5ccc:#f0f1ce"
+    bold_is_bright = True
+    #use_theme_colors = True
+    #font = <YOUR FONT> <SIZE>
+# ...
+```
+
+Otherwise, if you wish to have your default profile to have a Spaceduck colorscheme, you can instead
+replace the options you wish in the `[[default]]` field in your `config` file.
+

--- a/spaceduck.config
+++ b/spaceduck.config
@@ -1,0 +1,6 @@
+[[Spaceduck]]
+    palette = "#000000:#E33400:#5CCC96:#B3A1E6:#00A3CC:#F2CE00:#7A5CCC:#686F9A:#686F9A:#E33400:#5CCC96:#B3A1E6:#00A3CC:#F2CE00:#7A5CC:#F0F1CE"
+    background_color = "#0F111B"
+    cursor_color = "#ECF0C1"
+    foreground_color = "#ECF0C1"
+    background_image = None

--- a/spaceduck.config
+++ b/spaceduck.config
@@ -1,6 +1,0 @@
-[[Spaceduck]]
-    palette = "#000000:#E33400:#5CCC96:#B3A1E6:#00A3CC:#F2CE00:#7A5CCC:#686F9A:#686F9A:#E33400:#5CCC96:#B3A1E6:#00A3CC:#F2CE00:#7A5CC:#F0F1CE"
-    background_color = "#0F111B"
-    cursor_color = "#ECF0C1"
-    foreground_color = "#ECF0C1"
-    background_image = None

--- a/spaceduck.terminator
+++ b/spaceduck.terminator
@@ -1,0 +1,8 @@
+[[Spaceduck]]
+  background_color = "#0F111B"
+  cursor_color = "#ECF0C1"
+  cursor_color_fg = False
+  foreground_color = "#ECF0C1"
+  palette = "#000000:#e33400:#5ccc96:#b3a1e6:#00a3cc:#f2ce00:#7a5ccc:#686f9a:#686f9a:#e33400:#5ccc96:#b3a1e6:#00a3cc:#f2ce00:#7a5ccc:#f0f1ce"
+  bold_is_bright = True
+  #use_theme_colors = True


### PR DESCRIPTION
I've added the required configuration and (hopefully) detailed instructions to adding this colorscheme to Terminator. Any corrections and/or suggestions, please tell me.

Down below I'm including a screenshot, using [Manjaro's built-in colors function](https://gitlab.manjaro.org/packages/core/bash/-/blob/master/dot.bashrc):

![image](https://user-images.githubusercontent.com/72052712/171444345-9bae35cd-0781-4a7d-9575-9424df3addb7.png)
