### PR TITLE
Add support for Rio Terminal

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Take a look at [this thread](https://github.com/pineapplegiant/spaceduck-termina
 - [Termux](#termux)
 - [Xresources](#xresources)
 - [Mintty](#mintty)
+- [Rio](#rio)
 
 
 ## Iterm2
@@ -279,3 +280,54 @@ CursorColour=236,240,193        # #ECF0C1
 
 # vivid
 copy `spaceduck-vivid.yml` to your `.config` then add `export LS_COLORS="$(vivid generate ~/.config/spaceduck-vivid.yml)"` to the end of your `.bashrc`
+
+## Rio
+For more information on [Rio](https://github.com/raphamorim/rio), check out their repository. To get Spaceduck colors in your Rio terminal, copy the `spaceduck.toml` file to your rio `.config/rio/themes/` directory. Then, if not already created, set up your Rio config file at `.config/rio/config.toml`, and reference the theme using `theme="spaceduck"`
+
+*Note:* You will need to reload your terminal for the changes to take effect.
+
+You can also copy the details here:
+
+```
+[colors]
+# Regular colors
+background = '#0f111b'
+black = '#000000'
+blue = '#00a3cc'
+cursor = '#686f9a'
+cyan = '#7a5ccc'
+foreground  = '#ecf0c1'
+green = '#5ccc96'
+magenta = '#f2ce00'
+red = '#e33400'
+white = '#686f9a'
+yellow = '#b3a1e6'
+
+# UI colors
+tabs = '#686f9a'
+tabs-active = '#e33400'
+selection-foreground = '#686f9a'
+selection-background = '#ecf0c1'
+
+# Dim colors (Refernce to "dark" in most terminal configurations)
+dim-black = '#000000'
+dim-blue = '#00a3cc'
+dim-cyan = '#7a5ccc'
+dim-foreground = '#ecf0c1'
+dim-green = '#5ccc96'
+dim-magenta = '#f2ce00'
+dim-red = '#e33400'
+dim-white = '#686f9a'
+dim-yellow = '#b3a1e6'
+
+# Bright colors
+light-black =   '#686f9a'
+light-red =     '#e33400'
+light-green =   '#5ccc96'
+light-yellow =  '#f2ce00'
+light-blue =    '#00a3cc'
+light-magenta = '#b3a1e6'
+light-cyan =    '#7a5ccc'
+light-white =   '#f0f1ce'
+```
+

--- a/spaceduck.toml
+++ b/spaceduck.toml
@@ -1,0 +1,40 @@
+[colors]
+# Regular colors
+background = '#0f111b'
+black = '#000000'
+blue = '#00a3cc'
+cursor = '#686f9a'
+cyan = '#7a5ccc'
+foreground  = '#ecf0c1'
+green = '#5ccc96'
+magenta = '#f2ce00'
+red = '#e33400'
+white = '#686f9a'
+yellow = '#b3a1e6'
+
+# UI colors
+tabs = '#686f9a'
+tabs-active = '#e33400'
+selection-foreground = '#686f9a'
+selection-background = '#ecf0c1'
+
+# Dim colors
+dim-black = '#000000'
+dim-blue = '#00a3cc'
+dim-cyan = '#7a5ccc'
+dim-foreground = '#ecf0c1'
+dim-green = '#5ccc96'
+dim-magenta = '#f2ce00'
+dim-red = '#e33400'
+dim-white = '#686f9a'
+dim-yellow = '#b3a1e6'
+
+# Bright colors
+light-black =   '#686f9a'
+light-red =     '#e33400'
+light-green =   '#5ccc96'
+light-yellow =  '#f2ce00'
+light-blue =    '#00a3cc'
+light-magenta = '#b3a1e6'
+light-cyan =    '#7a5ccc'
+light-white =   '#f0f1ce'


### PR DESCRIPTION
Very nice theme! 

I just started fiddling with [Rio](https://github.com/raphamorim/rio) and thought I'd share my configuration for spaceduck. Because Rio is relatively new,  I was not able to find many published and widely available themes yet, so maybe this is a nice start 😃 

<img width="635" alt="image" src="https://github.com/pineapplegiant/spaceduck-terminal/assets/87335859/109e970b-d352-4fbc-86e3-bdee36d2fbe7">
